### PR TITLE
[Don't merge yet] read from registey

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/pos-analytics-lib",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "PoS analytics library. For web based queries of aggregated data.",
   "author": "Noam Berg <noam.berg@gmail.com>",
   "license": "MIT",

--- a/src/delegator.ts
+++ b/src/delegator.ts
@@ -13,7 +13,7 @@ import { addressToTopic, ascendingEvents, BlockInfo, Contracts, generateTxLink, 
 import { Delegator, DelegatorAction, DelegatorReward, DelegatorStake } from "./model";
 
 export async function getDelegator(address: string, etherumEndpoint: string): Promise<Delegator> {
-    const web3 = getWeb3(etherumEndpoint);  
+    const web3 = await getWeb3(etherumEndpoint);  
     const actions: DelegatorAction[] = [];
 
     // fix block for all "state" data.

--- a/src/guardian.ts
+++ b/src/guardian.ts
@@ -35,7 +35,7 @@ export async function getGuardians(networkNodeUrls: string[]): Promise<Guardian[
 }
 
 export async function getGuardian(address: string, ethereumEndpoint: string): Promise<GuardianInfo> {
-    const web3 = getWeb3(ethereumEndpoint);
+    const web3 = await getWeb3(ethereumEndpoint);
 
     // fix block for all "state" data.
     const block = await getCurrentBlockInfo(web3);

--- a/src/overview.ts
+++ b/src/overview.ts
@@ -12,16 +12,17 @@ import { fetchJson } from './helpers';
 import { PosOverview, PosOverviewSlice, PosOverviewData } from './model';
 
 export async function getOverview(networkNodeUrls: string[], ethereumEndpoint: string): Promise<PosOverview> {
+    let fullError = ''; 
     for(const url of networkNodeUrls) {
         try {
             const rawData = await fetchJson(url);
             return parseRawData(rawData.Payload, ethereumEndpoint);
         } catch (e) {
-            //console.log(`Warning: access to URL ${url} failed, trying another. Error: ${e} `)
+            fullError += `Warning: access to URL ${url} failed, trying another. Error: ${e}\n`;
         }
     }
 
-    throw new Error(`Error while creating PoS Overview, all Netowrk Node URL failed to respond.`)
+    throw new Error(`Error while creating list of Guardians, all Netowrk Node URL failed to respond. ${fullError}`);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -64,12 +65,8 @@ async function parseRawData(data:any, ethereumEndpoint:string) : Promise<PosOver
     });
     slices.sort((n1:any, n2:any) => n2.block_time - n1.block_time); // desc
 
-    // TODO uncomment when the new Interface is published
-    const web3 = getWeb3(ethereumEndpoint);
+    const web3 = await getWeb3(ethereumEndpoint, false);
     const block = await getCurrentBlockInfo(web3);
-    // const rewradsContract = getPoSContracts(web3, Contracts.Reward);
-    // const settings = await rewradsContract.methods.getSettings().call();
-    // const api = Number(settings.annualStakingRewardsRatePercentMille);
     const apy = 4000;
     
     return {

--- a/src/trial.test.ts
+++ b/src/trial.test.ts
@@ -14,10 +14,12 @@ export function toConsole(x:any){ return JSON.stringify(x, null, 2)}
 async function x() {
     const ethereumEndpoint = String(process.env.ETHEREUM_ENDPOINT);
     const nodeEndpoints = [
-        'http://54.168.36.177/services/management-service/status', // for dev non https
+        'https://0xcore.orbs.com/services/management-service/status',  // for actual production front-end with https
+        'http://0xaudit.orbs.com/services/management-service/status', // for dev non https
         'http://52.20.37.155/services/management-service/status',  // for dev non https
-        //https://guardian.v2beta.orbs.com/services/management-service/status  // for actual production front-end with https
     ];
+
+    const s = Date.now()
 
     const delegatorInfo = await getDelegator('0xB4D4f0E476Afe791B26B39985A65B1bC1BBAcdcA', ethereumEndpoint);
     const dfilepath = path.resolve(__dirname, `../data/delegator.json`);   
@@ -29,7 +31,7 @@ async function x() {
     fs.writeFileSync(gsfilepath, toConsole(guardians));
     //console.log(toConsole(guardians));
 
-    const guardianInfo = await getGuardian('0xf7ae622c77d0580f02bcb2f92380d61e3f6e466c', ethereumEndpoint);
+    const guardianInfo = await getGuardian('0xc5e624d6824e626a6f14457810e794e4603cfee2', ethereumEndpoint);
     const gfilepath = path.resolve(__dirname, `../data/guardian.json`);   
     fs.writeFileSync(gfilepath, toConsole(guardianInfo));
     //console.log(toConsole(guardianInfo));
@@ -37,7 +39,9 @@ async function x() {
     const overview = await getOverview(nodeEndpoints, ethereumEndpoint);
     const filepath = path.resolve(__dirname, `../data/overview.json`);   
     fs.writeFileSync(filepath, toConsole(overview));
-    // console.log(toConsole(overview));
+    //console.log(toConsole(overview));
+
+    console.log(`took ${(Date.now() - s) / 1000.0} seconds`)
 }
 
-x().then(()=> process.exit(0)).catch(e => console.log(`${e}`));
+x().then(()=> process.exit(0)).catch(e => console.log(`${e.stack}`));


### PR DESCRIPTION
Before each action read from registry a map of all the needed contracts and allow passing from one to the other.
this slows down by about 20%.

This also supports reading ABI of the 4 contracts from orbs contract repo (0.0.38).
 
Untill we have a need i suggest not merging this one.
